### PR TITLE
docs: renaming of functions and variables

### DIFF
--- a/script/Init.s.sol
+++ b/script/Init.s.sol
@@ -30,7 +30,7 @@ contract Init is MaxCountScript {
         // Approve the Lockup contracts to transfer the ERC-20 tokens from the sender.
         token.approve({ spender: address(lockup), value: type(uint256).max });
 
-        // Create 7 Lockup Linear streams with various amounts and durations.
+        // Create 7 LL streams with various amounts and durations.
         //
         // - 1st stream: meant to be depleted.
         // - 2th to 4th streams: pending or streaming.

--- a/shell/prepare-artifacts.sh
+++ b/shell/prepare-artifacts.sh
@@ -40,7 +40,7 @@ cp out-optimized/ISablierLockup.sol/ISablierLockup.json $lockup_interfaces
 lockup_libraries=./artifacts/libraries
 cp out-optimized/Errors.sol/Errors.json $lockup_libraries
 cp out-optimized/Helpers.sol/Helpers.json $lockup_libraries
-cp out-optimized/VestingMath.sol/VestingMath.json $lockup_libraries
+cp out-optimized/StreamingMath.sol/StreamingMath.json $lockup_libraries
 
 
 ################################################

--- a/src/SablierLockup.sol
+++ b/src/SablierLockup.sol
@@ -10,7 +10,7 @@ import { ILockupNFTDescriptor } from "./interfaces/ILockupNFTDescriptor.sol";
 import { ISablierLockup } from "./interfaces/ISablierLockup.sol";
 import { Errors } from "./libraries/Errors.sol";
 import { Helpers } from "./libraries/Helpers.sol";
-import { VestingMath } from "./libraries/VestingMath.sol";
+import { StreamingMath } from "./libraries/StreamingMath.sol";
 import { Lockup, LockupDynamic, LockupLinear, LockupTranched } from "./types/DataTypes.sol";
 
 /*
@@ -296,7 +296,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
 
     /// @inheritdoc SablierLockupBase
     function _calculateStreamedAmount(uint256 streamId) internal view override returns (uint128) {
-        // Load in memory the parameters used in {VestingMath}.
+        // Load in memory the parameters used in {StreamingMath}.
         uint40 blockTimestamp = uint40(block.timestamp);
         uint128 depositedAmount = _streams[streamId].amounts.deposited;
         Lockup.Model lockupModel = _streams[streamId].lockupModel;
@@ -306,7 +306,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
 
         // Calculate the streamed amount for the Lockup Dynamic model.
         if (lockupModel == Lockup.Model.LOCKUP_DYNAMIC) {
-            streamedAmount = VestingMath.calculateLockupDynamicStreamedAmount({
+            streamedAmount = StreamingMath.calculateLockupDynamicStreamedAmount({
                 depositedAmount: depositedAmount,
                 segments: _segments[streamId],
                 blockTimestamp: blockTimestamp,
@@ -316,7 +316,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         }
         // Calculate the streamed amount for the Lockup Linear model.
         else if (lockupModel == Lockup.Model.LOCKUP_LINEAR) {
-            streamedAmount = VestingMath.calculateLockupLinearStreamedAmount({
+            streamedAmount = StreamingMath.calculateLockupLinearStreamedAmount({
                 depositedAmount: depositedAmount,
                 blockTimestamp: blockTimestamp,
                 timestamps: timestamps,
@@ -327,7 +327,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         }
         // Calculate the streamed amount for the Lockup Tranched model.
         else if (lockupModel == Lockup.Model.LOCKUP_TRANCHED) {
-            streamedAmount = VestingMath.calculateLockupTranchedStreamedAmount({
+            streamedAmount = StreamingMath.calculateLockupTranchedStreamedAmount({
                 depositedAmount: depositedAmount,
                 blockTimestamp: blockTimestamp,
                 timestamps: timestamps,

--- a/src/SablierLockup.sol
+++ b/src/SablierLockup.sol
@@ -306,7 +306,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
 
         // Calculate the streamed amount for the Lockup Dynamic model.
         if (lockupModel == Lockup.Model.LOCKUP_DYNAMIC) {
-            streamedAmount = StreamingMath.calculateLockupDynamicStreamedAmount({
+            streamedAmount = StreamingMath.calculateStreamedAmountLD({
                 depositedAmount: depositedAmount,
                 segments: _segments[streamId],
                 blockTimestamp: blockTimestamp,
@@ -316,7 +316,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         }
         // Calculate the streamed amount for the Lockup Linear model.
         else if (lockupModel == Lockup.Model.LOCKUP_LINEAR) {
-            streamedAmount = StreamingMath.calculateLockupLinearStreamedAmount({
+            streamedAmount = StreamingMath.calculateStreamedAmountLL({
                 depositedAmount: depositedAmount,
                 blockTimestamp: blockTimestamp,
                 timestamps: timestamps,
@@ -327,7 +327,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         }
         // Calculate the streamed amount for the Lockup Tranched model.
         else if (lockupModel == Lockup.Model.LOCKUP_TRANCHED) {
-            streamedAmount = StreamingMath.calculateLockupTranchedStreamedAmount({
+            streamedAmount = StreamingMath.calculateStreamedAmountLT({
                 depositedAmount: depositedAmount,
                 blockTimestamp: blockTimestamp,
                 timestamps: timestamps,
@@ -400,7 +400,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         returns (uint256 streamId)
     {
         // Check: validate the user-provided parameters and segments.
-        Helpers.checkCreateLockupDynamic({
+        Helpers.checkCreateLD({
             sender: params.sender,
             timestamps: params.timestamps,
             depositAmount: params.depositAmount,
@@ -441,7 +441,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         returns (uint256 streamId)
     {
         // Check: validate the user-provided parameters and cliff time.
-        Helpers.checkCreateLockupLinear({
+        Helpers.checkCreateLL({
             sender: params.sender,
             timestamps: params.timestamps,
             cliffTime: cliffTime,
@@ -490,7 +490,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         returns (uint256 streamId)
     {
         // Check: validate the user-provided parameters and tranches.
-        Helpers.checkCreateLockupTranched({
+        Helpers.checkCreateLT({
             sender: params.sender,
             timestamps: params.timestamps,
             depositAmount: params.depositAmount,

--- a/src/SablierLockup.sol
+++ b/src/SablierLockup.sol
@@ -36,16 +36,16 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
     /// @inheritdoc ISablierLockup
     uint256 public immutable override MAX_COUNT;
 
-    /// @dev Cliff timestamp mapped by stream IDs. This is used in Lockup Linear models.
+    /// @dev Cliff timestamp mapped by stream IDs. This is used in LL models.
     mapping(uint256 streamId => uint40 cliffTime) internal _cliffs;
 
-    /// @dev Stream segments mapped by stream IDs. This is used in Lockup Dynamic models.
+    /// @dev Stream segments mapped by stream IDs. This is used in LD models.
     mapping(uint256 streamId => LockupDynamic.Segment[] segments) internal _segments;
 
-    /// @dev Stream tranches mapped by stream IDs. This is used in Lockup Tranched models.
+    /// @dev Stream tranches mapped by stream IDs. This is used in LT models.
     mapping(uint256 streamId => LockupTranched.Tranche[] tranches) internal _tranches;
 
-    /// @dev Unlock amounts mapped by stream IDs. This is used in Lockup Linear models.
+    /// @dev Unlock amounts mapped by stream IDs. This is used in LL models.
     mapping(uint256 streamId => LockupLinear.UnlockAmounts unlockAmounts) internal _unlockAmounts;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -54,8 +54,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
 
     /// @param initialAdmin The address of the initial contract admin.
     /// @param initialNFTDescriptor The address of the NFT descriptor contract.
-    /// @param maxCount The maximum number of segments and tranched allowed in Lockup Dynamic and Lockup Tranched
-    /// models, respectively.
+    /// @param maxCount The maximum number of segments and tranched allowed in LD and LT models, respectively.
     constructor(
         address initialAdmin,
         ILockupNFTDescriptor initialNFTDescriptor,
@@ -304,7 +303,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
         Lockup.Timestamps memory timestamps =
             Lockup.Timestamps({ start: _streams[streamId].startTime, end: _streams[streamId].endTime });
 
-        // Calculate the streamed amount for the Lockup Dynamic model.
+        // Calculate the streamed amount in case of LD model.
         if (lockupModel == Lockup.Model.LOCKUP_DYNAMIC) {
             streamedAmount = StreamingMath.calculateStreamedAmountLD({
                 depositedAmount: depositedAmount,
@@ -314,7 +313,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
                 withdrawnAmount: _streams[streamId].amounts.withdrawn
             });
         }
-        // Calculate the streamed amount for the Lockup Linear model.
+        // Calculate the streamed amount in case of LL model.
         else if (lockupModel == Lockup.Model.LOCKUP_LINEAR) {
             streamedAmount = StreamingMath.calculateStreamedAmountLL({
                 depositedAmount: depositedAmount,
@@ -325,7 +324,7 @@ contract SablierLockup is ISablierLockup, SablierLockupBase {
                 withdrawnAmount: _streams[streamId].amounts.withdrawn
             });
         }
-        // Calculate the streamed amount for the Lockup Tranched model.
+        // Calculate the streamed amount in case of LT model.
         else if (lockupModel == Lockup.Model.LOCKUP_TRANCHED) {
             streamedAmount = StreamingMath.calculateStreamedAmountLT({
                 depositedAmount: depositedAmount,

--- a/src/interfaces/ISablierBatchLockup.sol
+++ b/src/interfaces/ISablierBatchLockup.sol
@@ -14,7 +14,7 @@ interface ISablierBatchLockup {
                                SABLIER-LOCKUP-DYNAMIC
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a batch of Lockup Dynamic streams using `createWithDurationsLD`.
+    /// @notice Creates a batch of LD streams using `createWithDurationsLD`.
     ///
     /// @dev Requirements:
     /// - There must be at least one element in `batch`.
@@ -33,7 +33,7 @@ interface ISablierBatchLockup {
         external
         returns (uint256[] memory streamIds);
 
-    /// @notice Creates a batch of Lockup Dynamic streams using `createWithTimestampsLD`.
+    /// @notice Creates a batch of LD streams using `createWithTimestampsLD`.
     ///
     /// @dev Requirements:
     /// - There must be at least one element in `batch`.
@@ -56,7 +56,7 @@ interface ISablierBatchLockup {
                                SABLIER-LOCKUP-LINEAR
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a batch of Lockup Linear streams using `createWithDurationsLL`.
+    /// @notice Creates a batch of LL streams using `createWithDurationsLL`.
     ///
     /// @dev Requirements:
     /// - There must be at least one element in `batch`.
@@ -75,7 +75,7 @@ interface ISablierBatchLockup {
         external
         returns (uint256[] memory streamIds);
 
-    /// @notice Creates a batch of Lockup Linear streams using `createWithTimestampsLL`.
+    /// @notice Creates a batch of LL streams using `createWithTimestampsLL`.
     ///
     /// @dev Requirements:
     /// - There must be at least one element in `batch`.
@@ -98,7 +98,7 @@ interface ISablierBatchLockup {
                               SABLIER-LOCKUP-TRANCHED
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a batch of Lockup Tranched streams using `createWithDurationsLT`.
+    /// @notice Creates a batch of LT streams using `createWithDurationsLT`.
     ///
     /// @dev Requirements:
     /// - There must be at least one element in `batch`.
@@ -117,7 +117,7 @@ interface ISablierBatchLockup {
         external
         returns (uint256[] memory streamIds);
 
-    /// @notice Creates a batch of Lockup Tranched streams using `createWithTimestampsLT`.
+    /// @notice Creates a batch of LT streams using `createWithTimestampsLT`.
     ///
     /// @dev Requirements:
     /// - There must be at least one element in `batch`.

--- a/src/interfaces/ISablierLockup.sol
+++ b/src/interfaces/ISablierLockup.sol
@@ -11,7 +11,7 @@ interface ISablierLockup is ISablierLockupBase {
                                        EVENTS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a stream is created using Lockup dynamic model.
+    /// @notice Emitted when a stream is created using LD model.
     /// @param streamId The ID of the newly created stream.
     /// @param commonParams Common parameters emitted in Create events across all Lockup models.
     /// @param segments The segments the protocol uses to compose the dynamic distribution function.
@@ -19,7 +19,7 @@ interface ISablierLockup is ISablierLockupBase {
         uint256 indexed streamId, Lockup.CreateEventCommon commonParams, LockupDynamic.Segment[] segments
     );
 
-    /// @notice Emitted when a stream is created using Lockup linear model.
+    /// @notice Emitted when a stream is created using LL model.
     /// @param streamId The ID of the newly created stream.
     /// @param commonParams Common parameters emitted in Create events across all Lockup models.
     /// @param cliffTime The Unix timestamp for the cliff period's end. A value of zero means there is no cliff.
@@ -32,7 +32,7 @@ interface ISablierLockup is ISablierLockupBase {
         LockupLinear.UnlockAmounts unlockAmounts
     );
 
-    /// @notice Emitted when a stream is created using Lockup tranched model.
+    /// @notice Emitted when a stream is created using LT model.
     /// @param streamId The ID of the newly created stream.
     /// @param commonParams Common parameters emitted in Create events across all Lockup models.
     /// @param tranches The tranches the protocol uses to compose the tranched distribution function.
@@ -49,24 +49,24 @@ interface ISablierLockup is ISablierLockupBase {
     function MAX_COUNT() external view returns (uint256);
 
     /// @notice Retrieves the stream's cliff time, which is a Unix timestamp.  A value of zero means there is no cliff.
-    /// @dev Reverts if `streamId` references a null stream or a non Lockup Linear stream.
+    /// @dev Reverts if `streamId` references a null stream or a stream created using LD and LT model.
     /// @param streamId The stream ID for the query.
     function getCliffTime(uint256 streamId) external view returns (uint40 cliffTime);
 
     /// @notice Retrieves the segments used to compose the dynamic distribution function.
-    /// @dev Reverts if `streamId` references a null stream or a non Lockup Dynamic stream.
+    /// @dev Reverts if `streamId` references a null stream or a stream created without using LD model.
     /// @param streamId The stream ID for the query.
     /// @return segments See the documentation in {DataTypes}.
     function getSegments(uint256 streamId) external view returns (LockupDynamic.Segment[] memory segments);
 
     /// @notice Retrieves the tranches used to compose the tranched distribution function.
-    /// @dev Reverts if `streamId` references a null stream or a non Lockup Tranched stream.
+    /// @dev Reverts if `streamId` references a null stream or a stream created without using LT model.
     /// @param streamId The stream ID for the query.
     /// @return tranches See the documentation in {DataTypes}.
     function getTranches(uint256 streamId) external view returns (LockupTranched.Tranche[] memory tranches);
 
     /// @notice Retrieves the unlock amounts used to compose the linear distribution function.
-    /// @dev Reverts if `streamId` references a null stream or a non Lockup Linear stream.
+    /// @dev Reverts if `streamId` references a null stream or a stream created without using LL model.
     /// @param streamId The stream ID for the query.
     /// @return unlockAmounts See the documentation in {DataTypes}.
     function getUnlockAmounts(uint256 streamId)

--- a/src/libraries/Helpers.sol
+++ b/src/libraries/Helpers.sol
@@ -136,7 +136,7 @@ library Helpers {
                             PRIVATE CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Checks the user-provided cliff, end times and unlock amounts of a lockup linear stream.
+    /// @dev Checks the user-provided cliff, end times and unlock amounts of a stream with LL model.
     function _checkTimestampsAndUnlockAmounts(
         uint128 depositAmount,
         Lockup.Timestamps memory timestamps,

--- a/src/libraries/Helpers.sol
+++ b/src/libraries/Helpers.sol
@@ -76,7 +76,7 @@ library Helpers {
     }
 
     /// @dev Checks the parameters of the {SablierLockup-_createLD} function.
-    function checkCreateLockupDynamic(
+    function checkCreateLD(
         address sender,
         Lockup.Timestamps memory timestamps,
         uint128 depositAmount,
@@ -95,7 +95,7 @@ library Helpers {
     }
 
     /// @dev Checks the parameters of the {SablierLockup-_createLL} function.
-    function checkCreateLockupLinear(
+    function checkCreateLL(
         address sender,
         Lockup.Timestamps memory timestamps,
         uint40 cliffTime,
@@ -114,7 +114,7 @@ library Helpers {
     }
 
     /// @dev Checks the parameters of the {SablierLockup-_createLT} function.
-    function checkCreateLockupTranched(
+    function checkCreateLT(
         address sender,
         Lockup.Timestamps memory timestamps,
         uint128 depositAmount,

--- a/src/libraries/StreamingMath.sol
+++ b/src/libraries/StreamingMath.sol
@@ -8,9 +8,9 @@ import { UD60x18, ud } from "@prb/math/src/UD60x18.sol";
 
 import { Lockup, LockupDynamic, LockupLinear, LockupTranched } from "./../types/DataTypes.sol";
 
-/// @title VestingMath
-/// @notice Library with functions needed to calculate vested amount across lockup streams.
-library VestingMath {
+/// @title StreamingMath
+/// @notice Library with functions needed to calculate streamed amount across lockup streams.
+library StreamingMath {
     using CastingUint128 for uint128;
     using CastingUint40 for uint40;
 
@@ -26,7 +26,7 @@ library VestingMath {
     /// - $x$ is the elapsed time divided by the total duration of the current segment.
     /// - $exp$ is the current segment exponent.
     /// - $csa$ is the current segment amount.
-    /// - $\Sigma(esa)$ is the sum of all vested segments' amounts.
+    /// - $\Sigma(esa)$ is the sum of all streamed segments' amounts.
     ///
     /// Notes:
     /// 1. Normalization to 18 decimals is not needed because there is no mix of amounts with different decimals.
@@ -209,7 +209,7 @@ library VestingMath {
     ///
     /// Where:
     ///
-    /// - $\Sigma(eta)$ is the sum of all vested tranches' amounts.
+    /// - $\Sigma(eta)$ is the sum of all streamed tranches' amounts.
     ///
     /// Assumptions:
     /// 1. The sum of all tranche amounts does not overflow uint128, and equals the deposited amount.
@@ -241,13 +241,13 @@ library VestingMath {
             return 0;
         }
 
-        // Sum the amounts in all tranches that have already been vested.
+        // Sum the amounts in all tranches that have already been streamed.
         // Using unchecked arithmetic is safe because the sum of the tranche amounts is equal to the total amount
         // at this point.
         uint128 streamedAmount = tranches[0].amount;
         uint256 tranchesCount = tranches.length;
         for (uint256 i = 1; i < tranchesCount; ++i) {
-            // The loop breaks at the first tranche with a timestamp in the future. A tranche is considered vested if
+            // The loop breaks at the first tranche with a timestamp in the future. A tranche is considered streamed if
             // its timestamp is less than or equal to the block timestamp.
             if (tranches[i].timestamp > blockTimestamp) {
                 break;

--- a/src/libraries/StreamingMath.sol
+++ b/src/libraries/StreamingMath.sol
@@ -14,8 +14,8 @@ library StreamingMath {
     using CastingUint128 for uint128;
     using CastingUint40 for uint40;
 
-    /// @notice Calculates the streamed amount for a Lockup dynamic stream.
-    /// @dev Lockup dynamic model uses the following distribution function:
+    /// @notice Calculates the streamed amount of LD model.
+    /// @dev LD model uses the following distribution function:
     ///
     /// $$
     /// f(x) = x^{exp} * csa + \Sigma(esa)
@@ -112,8 +112,8 @@ library StreamingMath {
         }
     }
 
-    /// @notice Calculates the streamed amount for a Lockup linear stream.
-    /// @dev Lockup linear model uses the following distribution function:
+    /// @notice Calculates the streamed amount of LL model.
+    /// @dev LL model uses the following distribution function:
     ///
     /// $$
     ///        ( x * sa + s, block timestamp < cliff time
@@ -200,8 +200,8 @@ library StreamingMath {
         }
     }
 
-    /// @notice Calculates the streamed amount for a Lockup tranched stream.
-    /// @dev Lockup tranched model uses the following distribution function:
+    /// @notice Calculates the streamed amount of LT model.
+    /// @dev LT model uses the following distribution function:
     ///
     /// $$
     /// f(x) = \Sigma(eta)

--- a/src/libraries/StreamingMath.sol
+++ b/src/libraries/StreamingMath.sol
@@ -39,7 +39,7 @@ library StreamingMath {
     /// 2. The first segment's timestamp is greater than the start time.
     /// 3. The last segment's timestamp equals the end time.
     /// 4. The segment timestamps are arranged in ascending order.
-    function calculateLockupDynamicStreamedAmount(
+    function calculateStreamedAmountLD(
         uint128 depositedAmount,
         LockupDynamic.Segment[] memory segments,
         uint40 blockTimestamp,
@@ -133,7 +133,7 @@ library StreamingMath {
     /// the deposit amount.
     /// 2. The start time is before the end time.
     /// 3. If the cliff time is not zero, it is after the start time and before the end time.
-    function calculateLockupLinearStreamedAmount(
+    function calculateStreamedAmountLL(
         uint128 depositedAmount,
         uint40 blockTimestamp,
         Lockup.Timestamps memory timestamps,
@@ -216,7 +216,7 @@ library StreamingMath {
     /// 2. The first tranche's timestamp is greater than the start time.
     /// 3. The last tranche's timestamp equals the end time.
     /// 4. The tranche timestamps are arranged in ascending order.
-    function calculateLockupTranchedStreamedAmount(
+    function calculateStreamedAmountLT(
         uint128 depositedAmount,
         uint40 blockTimestamp,
         Lockup.Timestamps memory timestamps,

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -173,7 +173,7 @@ library Lockup {
     }
 
     /// @notice Enum representing the different distribution models used to create lockup streams.
-    /// @dev These distribution models determine the vesting function used in the calculations of the unlocked tokens.
+    /// @dev These distribution models determine the streaming function used in the calculations of the unlocked tokens.
     enum Model {
         LOCKUP_LINEAR,
         LOCKUP_DYNAMIC,

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -239,9 +239,9 @@ library Lockup {
     }
 }
 
-/// @notice Namespace for the structs used only in Lockup Dynamic model.
+/// @notice Namespace for the structs used only in LD model.
 library LockupDynamic {
-    /// @notice Segment struct to be stored in the Lockup Dynamic model.
+    /// @notice Segment struct stored to represent streams with LD model.
     /// @param amount The amount of tokens streamed in the segment, denoted in units of the token's decimals.
     /// @param exponent The exponent of the segment, denoted as a fixed-point number.
     /// @param timestamp The Unix timestamp indicating the segment's end.
@@ -263,7 +263,7 @@ library LockupDynamic {
     }
 }
 
-/// @notice Namespace for the structs used only in Lockup Linear model.
+/// @notice Namespace for the structs used only in LL model.
 library LockupLinear {
     /// @notice Struct encapsulating the cliff duration and the total duration used at runtime in
     /// {SablierLockup.createWithDurationsLL} function.
@@ -285,9 +285,9 @@ library LockupLinear {
     }
 }
 
-/// @notice Namespace for the structs used only in Lockup Tranched model.
+/// @notice Namespace for the structs used only in LT model.
 library LockupTranched {
-    /// @notice Tranche struct to be stored in the Lockup Tranched model.
+    /// @notice Tranche struct stored to represent streams with LT model.
     /// @param amount The amount of tokens to be unlocked in the tranche, denoted in units of the token's decimals.
     /// @param timestamp The Unix timestamp indicating the tranche's end.
     struct Tranche {

--- a/tests/fork/LockupDynamic.t.sol
+++ b/tests/fork/LockupDynamic.t.sol
@@ -165,8 +165,8 @@ abstract contract Lockup_Dynamic_Fork_Test is Fork_Test {
             params.segments
         );
 
-        // Check if the stream is settled. It is possible for a Lockup Dynamic stream to settle at the time of creation
-        // because some segment amounts can be zero or the last segment timestamp can be in the past.
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation because some
+        // segment amounts can be zero or the last segment timestamp can be in the past.
         vars.isSettled = lockup.refundableAmountOf(vars.streamId) == 0 || vars.timestamps.end <= getBlockTimestamp();
         vars.isCancelable = vars.isSettled ? false : true;
 

--- a/tests/fork/LockupLinear.t.sol
+++ b/tests/fork/LockupLinear.t.sol
@@ -187,7 +187,7 @@ abstract contract Lockup_Linear_Fork_Test is Fork_Test {
             params.cliffTime
         );
 
-        vars.streamedAmount = calculateLockupLinearStreamedAmount(
+        vars.streamedAmount = calculateStreamedAmountLL(
             params.timestamps.start, params.cliffTime, params.timestamps.end, params.depositAmount, params.unlockAmounts
         );
 

--- a/tests/fork/LockupLinear.t.sol
+++ b/tests/fork/LockupLinear.t.sol
@@ -191,8 +191,8 @@ abstract contract Lockup_Linear_Fork_Test is Fork_Test {
             params.timestamps.start, params.cliffTime, params.timestamps.end, params.depositAmount, params.unlockAmounts
         );
 
-        // Check if the stream is settled. It is possible for a Lockup Linear stream to settle at the time of creation
-        // in case 1. the start unlock amount equals the deposited amount 2. end time is in the past.
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation in case 1. the
+        // start unlock amount equals the deposited amount 2. end time is in the past.
         if (vars.streamedAmount == params.depositAmount) {
             vars.isSettled = true;
         } else {

--- a/tests/fork/LockupTranched.t.sol
+++ b/tests/fork/LockupTranched.t.sol
@@ -165,8 +165,8 @@ abstract contract Lockup_Tranched_Fork_Test is Fork_Test {
             params.tranches
         );
 
-        // Check if the stream is settled. It is possible for a Lockup Tranched stream to settle at the time of creation
-        // because some tranche amounts can be zero or the last tranche timestamp can be in the past
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation because some
+        // tranche amounts can be zero or the last tranche timestamp can be in the past
         vars.isSettled = lockup.refundableAmountOf(vars.streamId) == 0 || vars.timestamps.end <= getBlockTimestamp();
         vars.isCancelable = vars.isSettled ? false : true;
 

--- a/tests/integration/concrete/lockup-linear/streamed-amount-of/streamedAmountOf.t.sol
+++ b/tests/integration/concrete/lockup-linear/streamed-amount-of/streamedAmountOf.t.sol
@@ -66,7 +66,7 @@ contract StreamedAmountOf_Lockup_Linear_Integration_Concrete_Test is
         vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
 
         uint128 actualStreamedAmount = lockup.streamedAmountOf(streamId);
-        uint128 expectedStreamedAmount = calculateLockupLinearStreamedAmount(
+        uint128 expectedStreamedAmount = calculateStreamedAmountLL(
             _defaultParams.createWithTimestamps.timestamps.start,
             _defaultParams.cliffTime,
             _defaultParams.createWithTimestamps.timestamps.end,

--- a/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
@@ -66,8 +66,8 @@ contract CreateWithDurationsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrati
         _defaultParams.createWithDurations.transferable = true;
         uint256 streamId = lockup.createWithDurationsLD(_defaultParams.createWithDurations, segments);
 
-        // Check if the stream is settled. It is possible for a Lockup Dynamic stream to settle at the time of creation
-        // because some segment amounts can be zero.
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation because some
+        // segment amounts can be zero.
         vars.isSettled = lockup.refundableAmountOf(streamId) == 0;
         vars.isCancelable = vars.isSettled ? false : true;
 

--- a/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
@@ -217,8 +217,8 @@ contract CreateWithTimestampsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrat
         // Create the stream.
         uint256 streamId = lockup.createWithTimestampsLD(params, segments);
 
-        // Check if the stream is settled. It is possible for a Lockup Dynamic stream to settle at the time of creation
-        // because some segment amounts can be zero.
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation because some
+        // segment amounts can be zero.
         vars.isSettled = (lockup.getDepositedAmount(streamId) - lockup.streamedAmountOf(streamId)) == 0;
         vars.isCancelable = vars.isSettled ? false : params.cancelable;
 

--- a/tests/integration/fuzz/lockup-dynamic/streamedAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/streamedAmountOf.t.sol
@@ -45,7 +45,7 @@ contract StreamedAmountOf_Lockup_Dynamic_Integration_Fuzz_Test is Lockup_Dynamic
         // Run the test.
         uint128 actualStreamedAmount = lockup.streamedAmountOf(streamId);
         uint128 expectedStreamedAmount =
-            calculateLockupDynamicStreamedAmount(segments, defaults.START_TIME(), params.depositAmount);
+            calculateStreamedAmountLD(segments, defaults.START_TIME(), params.depositAmount);
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
@@ -95,8 +95,7 @@ contract StreamedAmountOf_Lockup_Dynamic_Integration_Fuzz_Test is Lockup_Dynamic
 
         // Run the test.
         uint128 actualStreamedAmount = lockup.streamedAmountOf(streamId);
-        uint128 expectedStreamedAmount =
-            calculateLockupDynamicStreamedAmount(segments, defaults.START_TIME(), depositAmount);
+        uint128 expectedStreamedAmount = calculateStreamedAmountLD(segments, defaults.START_TIME(), depositAmount);
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 

--- a/tests/integration/fuzz/lockup-dynamic/withdrawableAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/withdrawableAmountOf.t.sol
@@ -21,7 +21,7 @@ contract WithdrawableAmountOf_Lockup_Dynamic_Integration_Fuzz_Test is Lockup_Dyn
         // Run the test.
         uint128 actualWithdrawableAmount = lockup.withdrawableAmountOf(ids.defaultStream);
         uint128 expectedWithdrawableAmount =
-            calculateLockupDynamicStreamedAmount(defaults.segments(), defaults.START_TIME(), defaults.DEPOSIT_AMOUNT());
+            calculateStreamedAmountLD(defaults.segments(), defaults.START_TIME(), defaults.DEPOSIT_AMOUNT());
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
@@ -50,7 +50,7 @@ contract WithdrawableAmountOf_Lockup_Dynamic_Integration_Fuzz_Test is Lockup_Dyn
 
         // Bound the withdraw amount.
         uint128 streamedAmount =
-            calculateLockupDynamicStreamedAmount(defaults.segments(), defaults.START_TIME(), defaults.DEPOSIT_AMOUNT());
+            calculateStreamedAmountLD(defaults.segments(), defaults.START_TIME(), defaults.DEPOSIT_AMOUNT());
         withdrawAmount = boundUint128(withdrawAmount, 1, streamedAmount);
 
         // Make the withdrawal.

--- a/tests/integration/fuzz/lockup-linear/streamedAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-linear/streamedAmountOf.t.sol
@@ -80,7 +80,7 @@ contract StreamedAmountOf_Lockup_Linear_Integration_Fuzz_Test is Lockup_Linear_I
 
         // Run the test.
         uint128 actualStreamedAmount = lockup.streamedAmountOf(streamId);
-        uint128 expectedStreamedAmount = calculateLockupLinearStreamedAmount(
+        uint128 expectedStreamedAmount = calculateStreamedAmountLL(
             defaults.START_TIME(), defaults.CLIFF_TIME(), defaults.END_TIME(), depositAmount, unlockAmounts
         );
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");

--- a/tests/integration/fuzz/lockup-linear/withdrawableAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-linear/withdrawableAmountOf.t.sol
@@ -49,7 +49,7 @@ contract WithdrawableAmountOf_Lockup_Linear_Integration_Fuzz_Test is Lockup_Line
 
         // Run the test.
         uint128 actualWithdrawableAmount = lockup.withdrawableAmountOf(streamId);
-        uint128 expectedWithdrawableAmount = calculateLockupLinearStreamedAmount(
+        uint128 expectedWithdrawableAmount = calculateStreamedAmountLL(
             defaults.START_TIME(),
             defaults.CLIFF_TIME(),
             defaults.END_TIME(),
@@ -98,7 +98,7 @@ contract WithdrawableAmountOf_Lockup_Linear_Integration_Fuzz_Test is Lockup_Line
         vm.warp({ newTimestamp: defaults.START_TIME() + timeJump });
 
         // Bound the withdraw amount.
-        uint128 streamedAmount = calculateLockupLinearStreamedAmount(
+        uint128 streamedAmount = calculateStreamedAmountLL(
             defaults.START_TIME(), defaults.CLIFF_TIME(), defaults.END_TIME(), depositAmount, unlockAmounts
         );
         withdrawAmount = boundUint128(withdrawAmount, 1, streamedAmount);

--- a/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
@@ -66,8 +66,8 @@ contract CreateWithDurationsLT_Integration_Fuzz_Test is Lockup_Tranched_Integrat
         _defaultParams.createWithDurations.transferable = true;
         uint256 streamId = lockup.createWithDurationsLT(_defaultParams.createWithDurations, tranches);
 
-        // Check if the stream is settled. It is possible for a Lockup Tranched stream to settle at the time of creation
-        // because some tranche amounts can be zero.
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation because some
+        // tranche amounts can be zero.
         vars.isSettled = lockup.refundableAmountOf(streamId) == 0;
         vars.isCancelable = vars.isSettled ? false : true;
 

--- a/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
@@ -225,8 +225,8 @@ contract CreateWithTimestampsLT_Integration_Fuzz_Test is Lockup_Tranched_Integra
         // Fuzz the tranche amounts and calculate the deposit amount.
         Vars memory vars;
 
-        // Check if the stream is settled. It is possible for a Lockup Tranched stream to settle at the time of creation
-        // because some tranche amounts can be zero.
+        // Check if the stream is settled. It is possible for a stream to settle at the time of creation because some
+        // tranche amounts can be zero.
         vars.isSettled = (lockup.getDepositedAmount(streamId) - lockup.streamedAmountOf(streamId)) == 0;
         vars.isCancelable = vars.isSettled ? false : params.cancelable;
 

--- a/tests/integration/fuzz/lockup-tranched/streamedAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/streamedAmountOf.t.sol
@@ -52,7 +52,7 @@ contract StreamedAmountOf_Lockup_Tranched_Integration_Fuzz_Test is Lockup_Tranch
 
         // Run the test.
         uint128 actualStreamedAmount = lockup.streamedAmountOf(streamId);
-        uint128 expectedStreamedAmount = calculateLockupTranchedStreamedAmount(tranches, depositAmount);
+        uint128 expectedStreamedAmount = calculateStreamedAmountLT(tranches, depositAmount);
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 

--- a/tests/integration/fuzz/lockup-tranched/withdrawableAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/withdrawableAmountOf.t.sol
@@ -23,8 +23,7 @@ contract WithdrawableAmountOf_Lockup_Tranched_Integration_Fuzz_Test is Lockup_Tr
 
         // Run the test.
         uint128 actualWithdrawableAmount = lockup.withdrawableAmountOf(streamId);
-        uint128 expectedWithdrawableAmount =
-            calculateLockupTranchedStreamedAmount(defaults.tranches(), defaults.DEPOSIT_AMOUNT());
+        uint128 expectedWithdrawableAmount = calculateStreamedAmountLT(defaults.tranches(), defaults.DEPOSIT_AMOUNT());
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
@@ -55,7 +54,7 @@ contract WithdrawableAmountOf_Lockup_Tranched_Integration_Fuzz_Test is Lockup_Tr
         vm.warp({ newTimestamp: defaults.START_TIME() + timeJump });
 
         // Bound the withdraw amount.
-        uint128 streamedAmount = calculateLockupTranchedStreamedAmount(defaults.tranches(), defaults.DEPOSIT_AMOUNT());
+        uint128 streamedAmount = calculateStreamedAmountLT(defaults.tranches(), defaults.DEPOSIT_AMOUNT());
         withdrawAmount = boundUint128(withdrawAmount, 1, streamedAmount);
 
         // Make the withdrawal.

--- a/tests/invariant/Invariant.t.sol
+++ b/tests/invariant/Invariant.t.sol
@@ -351,7 +351,7 @@ contract Invariant_Test is Base_Test, StdInvariant {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                   LOCKUP DYNAMIC
+                                    LD MODEL
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev Unordered segment timestamps are not allowed.
@@ -373,7 +373,7 @@ contract Invariant_Test is Base_Test, StdInvariant {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                   LOCKUP LINEAR
+                                    LL MODEL
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev If it is not zero, the cliff time must be strictly greater than the start time.
@@ -409,7 +409,7 @@ contract Invariant_Test is Base_Test, StdInvariant {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                  LOCKUP TRANCHED
+                                    LT MODEL
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev Unordered tranche timestamps are not allowed.

--- a/tests/utils/Calculations.sol
+++ b/tests/utils/Calculations.sol
@@ -12,8 +12,8 @@ abstract contract Calculations {
     using CastingUint128 for uint128;
     using CastingUint40 for uint40;
 
-    /// @dev Replicates the logic of {StreamingMath.calculateLockupDynamicStreamedAmount}.
-    function calculateLockupDynamicStreamedAmount(
+    /// @dev Replicates the logic of {StreamingMath.calculateStreamedAmountLD}.
+    function calculateStreamedAmountLD(
         LockupDynamic.Segment[] memory segments,
         uint40 startTime,
         uint128 depositAmount
@@ -58,8 +58,8 @@ abstract contract Calculations {
         }
     }
 
-    /// @dev Helper function that replicates the logic of {StreamingMath.calculateLockupLinearStreamedAmount}.
-    function calculateLockupLinearStreamedAmount(
+    /// @dev Helper function that replicates the logic of {StreamingMath.calculateStreamedAmountLL}.
+    function calculateStreamedAmountLL(
         uint40 startTime,
         uint40 cliffTime,
         uint40 endTime,
@@ -99,8 +99,8 @@ abstract contract Calculations {
         }
     }
 
-    /// @dev Helper function that replicates the logic of {StreamingMath.calculateLockupTranchedStreamedAmount}.
-    function calculateLockupTranchedStreamedAmount(
+    /// @dev Helper function that replicates the logic of {StreamingMath.calculateStreamedAmountLT}.
+    function calculateStreamedAmountLT(
         LockupTranched.Tranche[] memory tranches,
         uint128 depositAmount
     )

--- a/tests/utils/Calculations.sol
+++ b/tests/utils/Calculations.sol
@@ -12,7 +12,7 @@ abstract contract Calculations {
     using CastingUint128 for uint128;
     using CastingUint40 for uint40;
 
-    /// @dev Replicates the logic of {VestingMath.calculateLockupDynamicStreamedAmount}.
+    /// @dev Replicates the logic of {StreamingMath.calculateLockupDynamicStreamedAmount}.
     function calculateLockupDynamicStreamedAmount(
         LockupDynamic.Segment[] memory segments,
         uint40 startTime,
@@ -58,7 +58,7 @@ abstract contract Calculations {
         }
     }
 
-    /// @dev Helper function that replicates the logic of {VestingMath.calculateLockupLinearStreamedAmount}.
+    /// @dev Helper function that replicates the logic of {StreamingMath.calculateLockupLinearStreamedAmount}.
     function calculateLockupLinearStreamedAmount(
         uint40 startTime,
         uint40 cliffTime,
@@ -99,7 +99,7 @@ abstract contract Calculations {
         }
     }
 
-    /// @dev Helper function that replicates the logic of {VestingMath.calculateLockupTranchedStreamedAmount}.
+    /// @dev Helper function that replicates the logic of {StreamingMath.calculateLockupTranchedStreamedAmount}.
     function calculateLockupTranchedStreamedAmount(
         LockupTranched.Tranche[] memory tranches,
         uint128 depositAmount

--- a/tests/utils/DeployOptimized.t.sol
+++ b/tests/utils/DeployOptimized.t.sol
@@ -17,11 +17,11 @@ abstract contract DeployOptimized is CommonBase {
         return ISablierBatchLockup(deployCode("out-optimized/SablierBatchLockup.sol/SablierBatchLockup.json"));
     }
 
-    /// @dev Deploys the optimized {Helpers} and {VestingMath} libraries.
-    function deployOptimizedLibraries() internal returns (address helpers, address vestingMath) {
+    /// @dev Deploys the optimized {Helpers} and {StreamingMath} libraries.
+    function deployOptimizedLibraries() internal returns (address helpers, address streamingMath) {
         // Deploy public libraries.
         helpers = deployCode("out-optimized/Helpers.sol/Helpers.json");
-        vestingMath = deployCode("out-optimized/VestingMath.sol/VestingMath.json");
+        streamingMath = deployCode("out-optimized/StreamingMath.sol/StreamingMath.json");
     }
 
     /// @dev Deploys {SablierLockup} from an optimized source compiled with `--via-ir`.
@@ -34,7 +34,7 @@ abstract contract DeployOptimized is CommonBase {
         returns (ISablierLockup lockup)
     {
         // Deploy the libraries.
-        (address helpers, address vestingMath) = deployOptimizedLibraries();
+        (address helpers, address streamingMath) = deployOptimizedLibraries();
 
         // Get the bytecode from {SablierLockup} artifact.
         string memory artifactJson = vm.readFile("out-optimized/SablierLockup.sol/SablierLockup.json");
@@ -48,8 +48,8 @@ abstract contract DeployOptimized is CommonBase {
         });
         rawBytecode = vm.replace({
             input: rawBytecode,
-            from: libraryPlaceholder("src/libraries/VestingMath.sol:VestingMath"),
-            to: vm.replace(vm.toString(vestingMath), "0x", "")
+            from: libraryPlaceholder("src/libraries/StreamingMath.sol:StreamingMath"),
+            to: vm.replace(vm.toString(streamingMath), "0x", "")
         });
 
         // Generate the creation bytecode with the constructor arguments.


### PR DESCRIPTION
Closes https://github.com/sablier-labs/lockup/issues/1134

- [x] Rename `VestingMath` to `StreamingMath`
- [x] In this function series: from `calculateLockupLinearStreamedAmount` to `calculateStreamedAmountLL`
- [x] And from `checkCreateLockupLinear ` to `checkCreateLL`
