### PR TITLE
ci: run fork tests on latest block

### DIFF
--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -32,8 +32,8 @@ abstract contract Fork_Test is Base_Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function setUp() public virtual override {
-        // Fork Ethereum Mainnet at a specific block number.
-        vm.createSelectFork({ blockNumber: 21_719_029, urlOrAlias: "mainnet" });
+        // Fork Ethereum Mainnet at the latest block number.
+        vm.createSelectFork({ urlOrAlias: "mainnet" });
 
         // Load deployed addresses from Ethereum mainnet.
         batchLockup = ISablierBatchLockup(0x3F6E8a8Cffe377c4649aCeB01e6F20c60fAA356c);


### PR DESCRIPTION
We should run fork tests only on the latest block. Since Ethereum global state is irreversible, fork tests will always pass at a specified block if it has been passing before. 

Running tests on the latest block would imply that the tests are passing on the most recent state of the Sablier protocol.

Merging this change through a PR so that we can verify that the fork tests are passing.