### PR TITLE
chore:update consistent comments for assertions

### DIFF
--- a/tests/fork/Lockup.t.sol
+++ b/tests/fork/Lockup.t.sol
@@ -170,7 +170,7 @@ abstract contract Lockup_Fork_Test is Fork_Test {
             assertEq(lockup.isCancelable(vars.streamId), params.create.cancelable, "isCancelable");
         }
 
-        // Assert that the aggregate balance has been updated.
+        // It should ensure that the aggregate balance has been updated.
         assertEq(
             lockup.aggregateBalance(FORK_TOKEN),
             vars.initialLockupBalance + params.create.depositAmount,
@@ -183,11 +183,11 @@ abstract contract Lockup_Fork_Test is Fork_Test {
         vars.actualLockupBalance = balances[0];
         vars.actualHolderBalance = balances[1];
 
-        // Assert that the Lockup contract's balance has been updated.
+        // It should ensure that the Lockup contract's balance has been updated.
         uint256 expectedLockupBalance = vars.initialLockupBalance + params.create.depositAmount;
         assertEq(vars.actualLockupBalance, expectedLockupBalance, "post-create Lockup balance");
 
-        // Assert that the holder's balance has been updated.
+        // It should ensure that the holder's balance has been updated.
         uint128 expectedHolderBalance = initialHolderBalance - params.create.depositAmount;
         assertEq(vars.actualHolderBalance, expectedHolderBalance, "post-create Holder balance");
     }
@@ -234,7 +234,7 @@ abstract contract Lockup_Fork_Test is Fork_Test {
                 amount: params.withdrawAmount
             });
 
-            // Assert that the stream's status is correct.
+            // It should ensure that the stream's status is correct.
             if (vars.isDepleted) {
                 vars.expectedStatus = Lockup.Status.DEPLETED;
             } else if (vars.isSettled) {
@@ -244,10 +244,10 @@ abstract contract Lockup_Fork_Test is Fork_Test {
             }
             assertEq(lockup.statusOf(vars.streamId), vars.expectedStatus, "post-withdraw stream status");
 
-            // Assert that the withdrawn amount has been updated.
+            // It should ensure that the withdrawn amount has been updated.
             assertEq(lockup.getWithdrawnAmount(vars.streamId), params.withdrawAmount, "post-withdraw withdrawnAmount");
 
-            // Assert that the aggregate balance has been updated.
+            // It should ensure that the aggregate balance has been updated.
             assertEq(
                 lockup.aggregateBalance(FORK_TOKEN),
                 vars.initialLockupBalance - params.withdrawAmount,
@@ -260,14 +260,14 @@ abstract contract Lockup_Fork_Test is Fork_Test {
             vars.actualLockupBalance = balances[0];
             vars.actualRecipientBalance = balances[1];
 
-            // Assert that the contract's balance has been updated.
+            // It should ensure that the contract's balance has been updated.
             uint256 expectedLockupBalance = vars.initialLockupBalance - params.withdrawAmount;
             assertEq(vars.actualLockupBalance, expectedLockupBalance, "post-withdraw Lockup balance");
 
-            // Assert that the contract's ETH balance has been updated.
+            // It should ensure that the contract's ETH balance has been updated.
             assertEq(address(lockup).balance, vars.initialLockupBalanceETH + FEE, "post-withdraw Lockup balance ETH");
 
-            // Assert that the Recipient's balance has been updated.
+            // It should ensure that the Recipient's balance has been updated.
             uint256 expectedRecipientBalance = vars.initialRecipientBalance + params.withdrawAmount;
             assertEq(vars.actualRecipientBalance, expectedRecipientBalance, "post-withdraw Recipient balance");
         }
@@ -308,14 +308,14 @@ abstract contract Lockup_Fork_Test is Fork_Test {
             resetPrank({ msgSender: params.create.sender });
             uint128 refundedAmount = lockup.cancel(vars.streamId);
 
-            // Assert that the refunded amount is correct.
+            // It should ensure that the refunded amount is correct.
             assertEq(refundedAmount, vars.senderAmount, "refundedAmount");
 
-            // Assert that the stream's status is correct.
+            // It should ensure that the stream's status is correct.
             vars.expectedStatus = vars.recipientAmount > 0 ? Lockup.Status.CANCELED : Lockup.Status.DEPLETED;
             assertEq(lockup.statusOf(vars.streamId), vars.expectedStatus, "post-cancel stream status");
 
-            // Assert that the aggregate balance has been updated.
+            // It should ensure that the aggregate balance has been updated.
             assertEq(
                 lockup.aggregateBalance(FORK_TOKEN), vars.initialLockupBalance - refundedAmount, "aggregateBalance"
             );
@@ -328,19 +328,19 @@ abstract contract Lockup_Fork_Test is Fork_Test {
             vars.actualSenderBalance = balances[1];
             vars.actualRecipientBalance = balances[2];
 
-            // Assert that the contract's balance has been updated.
+            // It should ensure that the contract's balance has been updated.
             uint256 expectedLockupBalance = vars.initialLockupBalance - vars.senderAmount;
             assertEq(vars.actualLockupBalance, expectedLockupBalance, "post-cancel Lockup balance");
 
-            // Assert that the Sender's balance has been updated.
+            // It should ensure that the Sender's balance has been updated.
             uint256 expectedSenderBalance = vars.initialSenderBalance + vars.senderAmount;
             assertEq(vars.actualSenderBalance, expectedSenderBalance, "post-cancel Sender balance");
 
-            // Assert that the Recipient's balance has not changed.
+            // It should ensure that the Recipient's balance has not changed.
             assertEq(vars.actualRecipientBalance, vars.initialRecipientBalance, "post-cancel Recipient balance");
         }
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         assertEq(lockup.ownerOf(vars.streamId), params.create.recipient, "post-cancel NFT owner");
     }
 }

--- a/tests/fork/LockupDynamic.t.sol
+++ b/tests/fork/LockupDynamic.t.sol
@@ -66,7 +66,7 @@ abstract contract Lockup_Dynamic_Fork_Test is Lockup_Fork_Test {
         // Create the stream.
         lockup.createWithTimestampsLD(params.create, params.segments);
 
-        // Assert that the stream is created with the correct parameters.
+        // It should ensure that the stream is created with the correct parameters.
         assertEq({ lockup: lockup, streamId: vars.streamId, expectedLockup: params.create });
         assertEq(lockup.getSegments(vars.streamId), params.segments);
 

--- a/tests/fork/LockupLinear.t.sol
+++ b/tests/fork/LockupLinear.t.sol
@@ -68,7 +68,7 @@ abstract contract Lockup_Linear_Fork_Test is Lockup_Fork_Test {
         // Create the stream.
         lockup.createWithTimestampsLL(params.create, params.unlockAmounts, params.cliffTime);
 
-        // Assert that the stream is created with the correct parameters.
+        // It should ensure that the stream is created with the correct parameters.
         assertEq({ lockup: lockup, streamId: vars.streamId, expectedLockup: params.create });
         assertEq(lockup.getCliffTime(vars.streamId), params.cliffTime, "cliffTime");
         assertEq(lockup.getUnlockAmounts(vars.streamId), params.unlockAmounts);

--- a/tests/fork/LockupTranched.t.sol
+++ b/tests/fork/LockupTranched.t.sol
@@ -67,7 +67,7 @@ abstract contract Lockup_Tranched_Fork_Test is Lockup_Fork_Test {
         // Create the stream.
         lockup.createWithTimestampsLT(params.create, params.tranches);
 
-        // Assert that the stream is created with the correct parameters.
+        // It should ensure that the stream is created with the correct parameters.
         assertEq({ streamId: vars.streamId, lockup: lockup, expectedLockup: params.create });
         assertEq(lockup.getTranches(vars.streamId), params.tranches);
 

--- a/tests/integration/concrete/batch-lockup/create-with-durations-ld/createWithDurationsLD.t.sol
+++ b/tests/integration/concrete/batch-lockup/create-with-durations-ld/createWithDurationsLD.t.sol
@@ -36,7 +36,7 @@ contract CreateWithDurationsLD_Integration_Test is Integration_Test {
 
         uint256 firstStreamId = lockup.nextStreamId();
 
-        // Assert that the batch of streams has been created successfully.
+        // It should ensure that the batch of streams has been created successfully.
         uint256[] memory actualStreamIds =
             batchLockup.createWithDurationsLD(lockup, dai, defaults.batchCreateWithDurationsLD());
         uint256[] memory expectedStreamIds = defaults.incrementalStreamIds({ firstStreamId: firstStreamId });

--- a/tests/integration/concrete/batch-lockup/create-with-durations-ll/createWithDurationsLL.t.sol
+++ b/tests/integration/concrete/batch-lockup/create-with-durations-ll/createWithDurationsLL.t.sol
@@ -37,7 +37,7 @@ contract CreateWithDurationsLL_Integration_Test is Integration_Test {
 
         uint256 firstStreamId = lockup.nextStreamId();
 
-        // Assert that the batch of streams has been created successfully.
+        // It should ensure that the batch of streams has been created successfully.
         uint256[] memory actualStreamIds =
             batchLockup.createWithDurationsLL(lockup, dai, defaults.batchCreateWithDurationsLL());
         uint256[] memory expectedStreamIds = defaults.incrementalStreamIds({ firstStreamId: firstStreamId });

--- a/tests/integration/concrete/batch-lockup/create-with-durations-lt/createWithDurationsLT.t.sol
+++ b/tests/integration/concrete/batch-lockup/create-with-durations-lt/createWithDurationsLT.t.sol
@@ -36,7 +36,7 @@ contract CreateWithDurationsLT_Integration_Test is Integration_Test {
 
         uint256 firstStreamId = lockup.nextStreamId();
 
-        // Assert that the batch of streams has been created successfully.
+        // It should ensure that the batch of streams has been created successfully.
         uint256[] memory actualStreamIds =
             batchLockup.createWithDurationsLT(lockup, dai, defaults.batchCreateWithDurationsLT());
         uint256[] memory expectedStreamIds = defaults.incrementalStreamIds({ firstStreamId: firstStreamId });

--- a/tests/integration/concrete/batch-lockup/create-with-timestamps-ld/createWithTimestampsLD.t.sol
+++ b/tests/integration/concrete/batch-lockup/create-with-timestamps-ld/createWithTimestampsLD.t.sol
@@ -36,7 +36,7 @@ contract CreateWithTimestampsLD_Integration_Test is Integration_Test {
 
         uint256 firstStreamId = lockup.nextStreamId();
 
-        // Assert that the batch of streams has been created successfully.
+        // It should ensure that the batch of streams has been created successfully.
         uint256[] memory actualStreamIds =
             batchLockup.createWithTimestampsLD(lockup, dai, defaults.batchCreateWithTimestampsLD());
         uint256[] memory expectedStreamIds = defaults.incrementalStreamIds({ firstStreamId: firstStreamId });

--- a/tests/integration/concrete/batch-lockup/create-with-timestamps-ll/createWithTimestamps.t.sol
+++ b/tests/integration/concrete/batch-lockup/create-with-timestamps-ll/createWithTimestamps.t.sol
@@ -37,7 +37,7 @@ contract CreateWithTimestampsLL_Integration_Test is Integration_Test {
 
         uint256 firstStreamId = lockup.nextStreamId();
 
-        // Assert that the batch of streams has been created successfully.
+        // It should ensure that the batch of streams has been created successfully.
         uint256[] memory actualStreamIds =
             batchLockup.createWithTimestampsLL(lockup, dai, defaults.batchCreateWithTimestampsLL());
         uint256[] memory expectedStreamIds = defaults.incrementalStreamIds({ firstStreamId: firstStreamId });

--- a/tests/integration/concrete/batch-lockup/create-with-timestamps-lt/createWithTimestampsLT.t.sol
+++ b/tests/integration/concrete/batch-lockup/create-with-timestamps-lt/createWithTimestampsLT.t.sol
@@ -36,7 +36,7 @@ contract CreateWithTimestampsLT_Integration_Test is Integration_Test {
 
         uint256 firstStreamId = lockup.nextStreamId();
 
-        // Assert that the batch of streams has been created successfully.
+        // It should ensure that the batch of streams has been created successfully.
         uint256[] memory actualStreamIds =
             batchLockup.createWithTimestampsLT(lockup, dai, defaults.batchCreateWithTimestampsLT());
         uint256[] memory expectedStreamIds = defaults.incrementalStreamIds({ firstStreamId: firstStreamId });

--- a/tests/integration/concrete/lockup-base/create-with-timestamps/createWithTimestamps.t.sol
+++ b/tests/integration/concrete/lockup-base/create-with-timestamps/createWithTimestamps.t.sol
@@ -30,7 +30,7 @@ abstract contract CreateWithTimestamps_Integration_Concrete_Test is Integration_
         assertTrue(lockup.isCancelable(streamId), "isCancelable");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
 
-        // Assert that the stream's status is "PENDING".
+        // It should ensure that the stream's status is "PENDING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);
         Lockup.Status expectedStatus = Lockup.Status.PENDING;
         assertEq(actualStatus, expectedStatus);

--- a/tests/integration/concrete/lockup-base/withdraw-max-and-transfer/withdrawMaxAndTransfer.t.sol
+++ b/tests/integration/concrete/lockup-base/withdraw-max-and-transfer/withdrawMaxAndTransfer.t.sol
@@ -120,10 +120,10 @@ contract WithdrawMaxAndTransfer_Integration_Concrete_Test is Integration_Test {
         uint128 actualWithdrawnAmount =
             lockup.withdrawMaxAndTransfer({ streamId: ids.defaultStream, newRecipient: users.alice });
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the operator is the new stream recipient (and NFT owner).
+        // It should ensure that the operator is the new stream recipient (and NFT owner).
         address actualRecipient = lockup.getRecipient(ids.defaultStream);
         address expectedRecipient = users.alice;
         assertEq(actualRecipient, expectedRecipient, "recipient");

--- a/tests/integration/concrete/lockup-base/withdraw-max/withdrawMax.t.sol
+++ b/tests/integration/concrete/lockup-base/withdraw-max/withdrawMax.t.sol
@@ -44,7 +44,7 @@ contract WithdrawMax_Integration_Concrete_Test is Integration_Test {
         bool isCancelable = lockup.isCancelable(ids.defaultStream);
         assertFalse(isCancelable, "isCancelable");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTowner = lockup.ownerOf({ tokenId: ids.defaultStream });
         address expectedNFTOwner = users.recipient;
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");
@@ -75,7 +75,7 @@ contract WithdrawMax_Integration_Concrete_Test is Integration_Test {
         // It should return the withdrawable amount.
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the stream's status is still "STREAMING".
+        // It should ensure that the stream's status is still "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);

--- a/tests/integration/concrete/lockup-base/withdraw-multiple/withdrawMultiple.t.sol
+++ b/tests/integration/concrete/lockup-base/withdraw-multiple/withdrawMultiple.t.sol
@@ -181,7 +181,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
         assertEq(lockup.getWithdrawnAmount(withdrawMultipleIds[1]), withdrawAmounts[1], "withdrawnAmount1");
         assertEq(lockup.getWithdrawnAmount(withdrawMultipleIds[2]), withdrawAmounts[2], "withdrawnAmount2");
 
-        // Assert that the stream NFTs have not been burned.
+        // It should ensure that the stream NFTs have not been burned.
         assertEq(lockup.getRecipient(withdrawMultipleIds[0]), users.recipient, "NFT owner0");
         assertEq(lockup.getRecipient(withdrawMultipleIds[1]), users.recipient, "NFT owner1");
         assertEq(lockup.getRecipient(withdrawMultipleIds[2]), users.recipient, "NFT owner2");

--- a/tests/integration/concrete/lockup-base/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/lockup-base/withdraw/withdraw.t.sol
@@ -237,7 +237,7 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test {
         bool isCancelable = lockup.isCancelable(ids.defaultStream);
         assertFalse(isCancelable, "isCancelable");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTowner = lockup.ownerOf({ tokenId: ids.defaultStream });
         address expectedNFTOwner = users.recipient;
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");
@@ -285,7 +285,7 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test {
         uint128 expectedWithdrawnAmount = withdrawAmount;
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTowner = lockup.ownerOf({ tokenId: ids.defaultStream });
         address expectedNFTOwner = users.recipient;
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");
@@ -418,7 +418,7 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test {
             amount: withdrawAmount
         });
 
-        // Assert that the stream's status is still "STREAMING".
+        // It should ensure that the stream's status is still "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(ids.recipientReentrantStream);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);
@@ -481,7 +481,7 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test {
         // Make the withdrawal.
         lockup.withdraw({ streamId: ids.recipientGoodStream, to: address(recipientGood), amount: withdrawAmount });
 
-        // Assert that the stream's status is still "STREAMING".
+        // It should ensure that the stream's status is still "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(ids.recipientGoodStream);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);

--- a/tests/integration/concrete/lockup-dynamic/create-with-durations-ld/createWithDurationsLD.t.sol
+++ b/tests/integration/concrete/lockup-dynamic/create-with-durations-ld/createWithDurationsLD.t.sol
@@ -160,7 +160,7 @@ contract CreateWithDurationsLD_Integration_Concrete_Test is Lockup_Dynamic_Integ
         // Create the stream.
         uint256 streamId = createDefaultStreamWithDurations();
 
-        // Assert that the stream has been created.
+        // It should ensure that the stream has been created.
         assertEq(lockup.getDepositedAmount(streamId), defaults.DEPOSIT_AMOUNT(), "depositedAmount");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
@@ -174,7 +174,7 @@ contract CreateWithDurationsLD_Integration_Concrete_Test is Lockup_Dynamic_Integ
         assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
-        // Assert that the stream's status is "STREAMING".
+        // It should ensure that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);

--- a/tests/integration/concrete/lockup-linear/create-with-durations-ll/createWithDurationsLL.t.sol
+++ b/tests/integration/concrete/lockup-linear/create-with-durations-ll/createWithDurationsLL.t.sol
@@ -75,7 +75,7 @@ contract CreateWithDurationsLL_Integration_Concrete_Test is Lockup_Linear_Integr
         assertEq(lockup.getUnlockAmounts(streamId), _defaultParams.unlockAmounts);
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
-        // Assert that the stream's status is "STREAMING".
+        // It should ensure that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);

--- a/tests/integration/concrete/lockup-tranched/create-with-durations-lt/createWithDurationsLT.t.sol
+++ b/tests/integration/concrete/lockup-tranched/create-with-durations-lt/createWithDurationsLT.t.sol
@@ -152,7 +152,7 @@ contract CreateWithDurationsLT_Integration_Concrete_Test is Lockup_Tranched_Inte
         // Create the stream.
         uint256 streamId = createDefaultStreamWithDurations(tranchesWithDurations);
 
-        // Assert that the stream has been created.
+        // It should ensure that the stream has been created.
         assertEq(lockup.getDepositedAmount(streamId), defaults.DEPOSIT_AMOUNT(), "depositedAmount");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), true, "isCancelable");
@@ -168,7 +168,7 @@ contract CreateWithDurationsLT_Integration_Concrete_Test is Lockup_Tranched_Inte
 
         assertEq(lockup.getTranches(streamId), tranches);
 
-        // Assert that the stream's status is "STREAMING".
+        // It should ensure that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);

--- a/tests/integration/fuzz/lockup-base/cancel.t.sol
+++ b/tests/integration/fuzz/lockup-base/cancel.t.sol
@@ -28,12 +28,12 @@ abstract contract Cancel_Integration_Fuzz_Test is Integration_Test {
         // Cancel the stream.
         uint128 refundedAmount = lockup.cancel(ids.defaultStream);
 
-        // Assert that the stream's status is "DEPLETED".
+        // It should ensure that the stream's status is "DEPLETED".
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus = Lockup.Status.DEPLETED;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the stream is not cancelable anymore.
+        // It should ensure that the stream is not cancelable anymore.
         bool isCancelable = lockup.isCancelable(ids.defaultStream);
         assertFalse(isCancelable, "isCancelable");
 
@@ -102,22 +102,22 @@ abstract contract Cancel_Integration_Fuzz_Test is Integration_Test {
         // Cancel the stream.
         uint128 refundedAmount = lockup.cancel(ids.recipientGoodStream);
 
-        // Assert that the amount refunded matches the expected value.
+        // It should ensure that the amount refunded matches the expected value.
         assertEq(refundedAmount, senderAmount, "refundedAmount");
 
-        // Assert that the stream's status is "CANCELED".
+        // It should ensure that the stream's status is "CANCELED".
         Lockup.Status actualStatus = lockup.statusOf(ids.recipientGoodStream);
         Lockup.Status expectedStatus = Lockup.Status.CANCELED;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the stream is not cancelable anymore.
+        // It should ensure that the stream is not cancelable anymore.
         bool isCancelable = lockup.isCancelable(ids.recipientGoodStream);
         assertFalse(isCancelable, "isCancelable");
 
         // It should update the aggrate balance.
         assertEq(lockup.aggregateBalance(dai), previousAggregateAmount - refundedAmount, "aggregateBalance");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTOwner = lockup.ownerOf({ tokenId: ids.recipientGoodStream });
         address expectedNFTOwner = address(recipientGood);
         assertEq(actualNFTOwner, expectedNFTOwner, "NFT owner");

--- a/tests/integration/fuzz/lockup-base/withdraw.t.sol
+++ b/tests/integration/fuzz/lockup-base/withdraw.t.sol
@@ -35,12 +35,12 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test {
             amount: defaults.STREAMED_AMOUNT_26_PERCENT()
         });
 
-        // Assert that the stream's status is still "STREAMING".
+        // It should ensure that the stream's status is still "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = defaults.STREAMED_AMOUNT_26_PERCENT();
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
@@ -69,12 +69,12 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test {
         // Make the withdrawal.
         lockup.withdraw({ streamId: ids.defaultStream, to: to, amount: defaults.STREAMED_AMOUNT_26_PERCENT() });
 
-        // Assert that the stream's status is still "STREAMING".
+        // It should ensure that the stream's status is still "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = defaults.STREAMED_AMOUNT_26_PERCENT();
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
@@ -131,17 +131,17 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test {
         uint128 refundedAmount = lockup.getRefundedAmount(ids.defaultStream);
         bool isDepleted = withdrawAmount == defaults.DEPOSIT_AMOUNT() - refundedAmount;
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus = isDepleted ? Lockup.Status.DEPLETED : Lockup.Status.CANCELED;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = withdrawAmount;
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTowner = lockup.ownerOf({ tokenId: ids.defaultStream });
         address expectedNFTOwner = users.recipient;
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");
@@ -200,7 +200,7 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test {
         bool isDepleted = withdrawAmount == defaults.DEPOSIT_AMOUNT();
         bool isSettled = lockup.refundableAmountOf(ids.defaultStream) == 0;
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus;
         if (isDepleted) {
@@ -212,12 +212,12 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test {
         }
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = withdrawAmount;
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTowner = lockup.ownerOf({ tokenId: ids.defaultStream });
         address expectedNFTOwner = users.recipient;
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");

--- a/tests/integration/fuzz/lockup-base/withdrawMax.t.sol
+++ b/tests/integration/fuzz/lockup-base/withdrawMax.t.sol
@@ -28,21 +28,21 @@ contract WithdrawMax_Integration_Fuzz_Test is Integration_Test {
         // Make the max withdrawal.
         lockup.withdrawMax({ streamId: ids.defaultStream, to: users.recipient });
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = defaults.DEPOSIT_AMOUNT();
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the stream's status is "DEPLETED".
+        // It should ensure that the stream's status is "DEPLETED".
         Lockup.Status actualStatus = lockup.statusOf(ids.defaultStream);
         Lockup.Status expectedStatus = Lockup.Status.DEPLETED;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the stream is not cancelable anymore.
+        // It should ensure that the stream is not cancelable anymore.
         bool isCancelable = lockup.isCancelable(ids.defaultStream);
         assertFalse(isCancelable, "isCancelable");
 
-        // Assert that the not burned NFT.
+        // It should ensure that the not burned NFT.
         address actualNFTowner = lockup.ownerOf({ tokenId: ids.defaultStream });
         address expectedNFTOwner = users.recipient;
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");
@@ -72,7 +72,7 @@ contract WithdrawMax_Integration_Fuzz_Test is Integration_Test {
         // Make the max withdrawal.
         lockup.withdrawMax({ streamId: ids.defaultStream, to: users.recipient });
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = withdrawAmount;
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");

--- a/tests/integration/fuzz/lockup-base/withdrawMaxAndTransfer.t.sol
+++ b/tests/integration/fuzz/lockup-base/withdrawMaxAndTransfer.t.sol
@@ -53,12 +53,12 @@ contract WithdrawMaxAndTransfer_Integration_Fuzz_Test is Integration_Test {
         // Make the max withdrawal and transfer the NFT.
         lockup.withdrawMaxAndTransfer({ streamId: ids.defaultStream, newRecipient: newRecipient });
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         uint128 actualWithdrawnAmount = lockup.getWithdrawnAmount(ids.defaultStream);
         uint128 expectedWithdrawnAmount = withdrawAmount;
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
 
-        // Assert that the fuzzed recipient is the new stream recipient (and NFT owner).
+        // It should ensure that the fuzzed recipient is the new stream recipient (and NFT owner).
         address actualRecipient = lockup.getRecipient(ids.defaultStream);
         address expectedRecipient = newRecipient;
         assertEq(actualRecipient, expectedRecipient, "recipient");

--- a/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
@@ -82,17 +82,17 @@ contract CreateWithDurationsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrati
         assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);
         vars.expectedStatus = vars.isSettled ? Lockup.Status.SETTLED : Lockup.Status.STREAMING;
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the next stream ID has been bumped.
+        // It should ensure that the next stream ID has been bumped.
         vars.actualNextStreamId = lockup.nextStreamId();
         vars.expectedNextStreamId = streamId + 1;
         assertEq(vars.actualNextStreamId, vars.expectedNextStreamId, "nextStreamId");
 
-        // Assert that the NFT has been minted.
+        // It should ensure that the NFT has been minted.
         vars.actualNFTOwner = lockup.ownerOf({ tokenId: streamId });
         vars.expectedNFTOwner = users.recipient;
         assertEq(vars.actualNFTOwner, vars.expectedNFTOwner, "NFT owner");

--- a/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
@@ -229,7 +229,7 @@ contract CreateWithTimestampsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrat
         assertEq(lockup.getSegments(streamId), segments);
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);
         if (params.timestamps.start > getBlockTimestamp()) {
             vars.expectedStatus = Lockup.Status.PENDING;
@@ -240,17 +240,17 @@ contract CreateWithTimestampsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrat
         }
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the next stream ID has been bumped.
+        // It should ensure that the next stream ID has been bumped.
         vars.actualNextStreamId = lockup.nextStreamId();
         vars.expectedNextStreamId = streamId + 1;
         assertEq(vars.actualNextStreamId, vars.expectedNextStreamId, "nextStreamId");
 
-        // Assert that the NFT has been minted.
+        // It should ensure that the NFT has been minted.
         vars.actualNFTOwner = lockup.ownerOf({ tokenId: streamId });
         vars.expectedNFTOwner = params.recipient;
         assertEq(vars.actualNFTOwner, vars.expectedNFTOwner, "NFT owner");
 
-        // Assert that the aggragate balance has been updated.
+        // It should ensure that the aggragate balance has been updated.
         assertEq(lockup.aggregateBalance(dai), previousAggregateAmount + params.depositAmount);
     }
 }

--- a/tests/integration/fuzz/lockup-dynamic/streamedAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/streamedAmountOf.t.sol
@@ -144,7 +144,7 @@ contract StreamedAmountOf_Lockup_Dynamic_Integration_Fuzz_Test is Lockup_Dynamic
         // Warp to the future for the second time.
         vm.warp({ newTimestamp: defaults.START_TIME() + timeWarp1 });
 
-        // Assert that this streamed amount is greater than or equal to the previous streamed amount.
+        // It should ensure that this streamed amount is greater than or equal to the previous streamed amount.
         uint128 streamedAmount1 = lockup.streamedAmountOf(streamId);
         assertGe(streamedAmount1, streamedAmount0, "streamedAmount");
     }

--- a/tests/integration/fuzz/lockup-dynamic/withdraw.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/withdraw.t.sol
@@ -117,7 +117,7 @@ contract Withdraw_Lockup_Dynamic_Integration_Fuzz_Test is
         vars.isDepleted = vars.withdrawAmount == vars.depositAmount;
         vars.isSettled = lockup.refundableAmountOf(vars.streamId) == 0;
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(vars.streamId);
         if (vars.isDepleted) {
             vars.expectedStatus = Lockup.Status.DEPLETED;
@@ -128,7 +128,7 @@ contract Withdraw_Lockup_Dynamic_Integration_Fuzz_Test is
         }
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         vars.actualWithdrawnAmount = lockup.getWithdrawnAmount(vars.streamId);
         vars.expectedWithdrawnAmount = vars.withdrawAmount;
         assertEq(vars.actualWithdrawnAmount, vars.expectedWithdrawnAmount, "withdrawnAmount");

--- a/tests/integration/fuzz/lockup-linear/createWithDurationsLL.t.sol
+++ b/tests/integration/fuzz/lockup-linear/createWithDurationsLL.t.sol
@@ -53,12 +53,12 @@ contract CreateWithDurationsLL_Integration_Fuzz_Test is Lockup_Linear_Integratio
         assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertEq(lockup.getUnlockAmounts(streamId), unlockAmounts);
 
-        // Assert that the stream's status is "STREAMING".
+        // It should ensure that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);
         Lockup.Status expectedStatus = Lockup.Status.STREAMING;
         assertEq(actualStatus, expectedStatus);
 
-        // Assert that the next stream ID has been bumped.
+        // It should ensure that the next stream ID has been bumped.
         uint256 actualNextStreamId = lockup.nextStreamId();
         uint256 expectedNextStreamId = streamId + 1;
         assertEq(actualNextStreamId, expectedNextStreamId, "nextStreamId");

--- a/tests/integration/fuzz/lockup-linear/createWithTimestampsLL.t.sol
+++ b/tests/integration/fuzz/lockup-linear/createWithTimestampsLL.t.sol
@@ -178,23 +178,23 @@ contract CreateWithTimestampsLL_Integration_Fuzz_Test is Lockup_Linear_Integrati
         assertEq(lockup.getUnlockAmounts(vars.actualStreamId), unlockAmounts);
         assertFalse(lockup.wasCanceled(vars.actualStreamId), "wasCanceled");
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(vars.actualStreamId);
         vars.expectedStatus =
             params.timestamps.start > getBlockTimestamp() ? Lockup.Status.PENDING : Lockup.Status.STREAMING;
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the next stream ID has been bumped.
+        // It should ensure that the next stream ID has been bumped.
         vars.actualNextStreamId = lockup.nextStreamId();
         vars.expectedNextStreamId = vars.actualStreamId + 1;
         assertEq(vars.actualNextStreamId, vars.expectedNextStreamId, "nextStreamId");
 
-        // Assert that the NFT has been minted.
+        // It should ensure that the NFT has been minted.
         vars.actualNFTOwner = lockup.ownerOf({ tokenId: vars.actualStreamId });
         vars.expectedNFTOwner = params.recipient;
         assertEq(vars.actualNFTOwner, vars.expectedNFTOwner, "NFT owner");
 
-        // Assert that the aggragate balance has been updated.
+        // It should ensure that the aggragate balance has been updated.
         assertEq(lockup.aggregateBalance(dai), previousAggregateAmount + params.depositAmount);
     }
 }

--- a/tests/integration/fuzz/lockup-linear/streamedAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-linear/streamedAmountOf.t.sol
@@ -126,7 +126,7 @@ contract StreamedAmountOf_Lockup_Linear_Integration_Fuzz_Test is Lockup_Linear_I
         // Warp to the future for the second time.
         vm.warp({ newTimestamp: defaults.START_TIME() + timeWarp1 });
 
-        // Assert that this streamed amount is greater than or equal to the previous streamed amount.
+        // It should ensure that this streamed amount is greater than or equal to the previous streamed amount.
         uint128 streamedAmount1 = lockup.streamedAmountOf(streamId);
         assertGe(streamedAmount1, streamedAmount0, "streamedAmount");
     }

--- a/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
@@ -83,17 +83,17 @@ contract CreateWithDurationsLT_Integration_Fuzz_Test is Lockup_Tranched_Integrat
         assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);
         vars.expectedStatus = vars.isSettled ? Lockup.Status.SETTLED : Lockup.Status.STREAMING;
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the next stream ID has been bumped.
+        // It should ensure that the next stream ID has been bumped.
         vars.actualNextStreamId = lockup.nextStreamId();
         vars.expectedNextStreamId = streamId + 1;
         assertEq(vars.actualNextStreamId, vars.expectedNextStreamId, "nextStreamId");
 
-        // Assert that the NFT has been minted.
+        // It should ensure that the NFT has been minted.
         vars.actualNFTOwner = lockup.ownerOf({ tokenId: streamId });
         vars.expectedNFTOwner = users.recipient;
         assertEq(vars.actualNFTOwner, vars.expectedNFTOwner, "NFT owner");

--- a/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
@@ -237,7 +237,7 @@ contract CreateWithTimestampsLT_Integration_Fuzz_Test is Lockup_Tranched_Integra
         assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);
         if (params.timestamps.start > getBlockTimestamp()) {
             vars.expectedStatus = Lockup.Status.PENDING;
@@ -248,17 +248,17 @@ contract CreateWithTimestampsLT_Integration_Fuzz_Test is Lockup_Tranched_Integra
         }
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the next stream ID has been bumped.
+        // It should ensure that the next stream ID has been bumped.
         vars.actualNextStreamId = lockup.nextStreamId();
         vars.expectedNextStreamId = streamId + 1;
         assertEq(vars.actualNextStreamId, vars.expectedNextStreamId, "nextStreamId");
 
-        // Assert that the NFT has been minted.
+        // It should ensure that the NFT has been minted.
         vars.actualNFTOwner = lockup.ownerOf({ tokenId: streamId });
         vars.expectedNFTOwner = params.recipient;
         assertEq(vars.actualNFTOwner, vars.expectedNFTOwner, "NFT owner");
 
-        // Assert that the aggragate balance has been updated.
+        // It should ensure that the aggragate balance has been updated.
         assertEq(lockup.aggregateBalance(dai), previousAggregateAmount + params.depositAmount);
     }
 }

--- a/tests/integration/fuzz/lockup-tranched/streamedAmountOf.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/streamedAmountOf.t.sol
@@ -102,7 +102,7 @@ contract StreamedAmountOf_Lockup_Tranched_Integration_Fuzz_Test is Lockup_Tranch
         // Warp to the future for the second time.
         vm.warp({ newTimestamp: defaults.START_TIME() + timeWarp1 });
 
-        // Assert that this streamed amount is greater than or equal to the previous streamed amount.
+        // It should ensure that this streamed amount is greater than or equal to the previous streamed amount.
         uint128 streamedAmount1 = lockup.streamedAmountOf(streamId);
         assertGe(streamedAmount1, streamedAmount0, "streamedAmount");
     }

--- a/tests/integration/fuzz/lockup-tranched/withdraw.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/withdraw.t.sol
@@ -116,7 +116,7 @@ contract Withdraw_Lockup_Tranched_Integration_Fuzz_Test is
         vars.isDepleted = vars.withdrawAmount == vars.depositAmount;
         vars.isSettled = lockup.refundableAmountOf(vars.streamId) == 0;
 
-        // Assert that the stream's status is correct.
+        // It should ensure that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(vars.streamId);
         if (vars.isDepleted) {
             vars.expectedStatus = Lockup.Status.DEPLETED;
@@ -127,7 +127,7 @@ contract Withdraw_Lockup_Tranched_Integration_Fuzz_Test is
         }
         assertEq(vars.actualStatus, vars.expectedStatus);
 
-        // Assert that the withdrawn amount has been updated.
+        // It should ensure that the withdrawn amount has been updated.
         vars.actualWithdrawnAmount = lockup.getWithdrawnAmount(vars.streamId);
         vars.expectedWithdrawnAmount = vars.withdrawAmount;
         assertEq(vars.actualWithdrawnAmount, vars.expectedWithdrawnAmount, "withdrawnAmount");


### PR DESCRIPTION
Standardised the commenting formats for assertions  across tests. Adopted the `It should ....` format for clarity and uniformity