### PR TITLE
Remove remappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ typechain-types
 *.log
 .DS_Store
 .pnp.*
+bun.lockb
 deployments.md
 lcov.info
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ Install Lockup using your favorite package manager, e.g., with Bun:
 bun add @sablier/lockup
 ```
 
-Then, if you are using Foundry, you need to add these to your `remappings.txt` file:
-
-```text
-@sablier/lockup/=node_modules/@sablier/lockup/
-@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
-@prb/math/=node_modules/@prb/math/
-```
-
 ### Git Submodules
 
 This installation method is not recommended, but it is available for those who prefer it.
@@ -55,14 +47,6 @@ Second, install the project's dependencies:
 
 ```shell
 forge install --no-commit OpenZeppelin/openzeppelin-contracts@v5.0.2 PaulRBerg/prb-math@v4.1.0
-```
-
-Finally, add these to your `remappings.txt` file:
-
-```text
-@sablier/lockup/=lib/lockup/
-@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
-@prb/math/=lib/prb-math/
 ```
 
 ## Usage

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,0 @@
-@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
-@prb/math/=node_modules/@prb/math/
-@sablier/evm-utils/=node_modules/@sablier/evm-utils/
-forge-std/=node_modules/forge-std/
-solady/=node_modules/solady/
-solarray/=node_modules/solarray/


### PR DESCRIPTION
Closes https://github.com/sablier-labs/lockup/issues/1237 

**Note:** I didn't remove the section about `remappings` in the case of `forge install`, as it would still be required when using git submodules.