### PR TITLE
feat: function to calculate min fee in wei for a given stream ID

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@openzeppelin/contracts": "5.3.0",
         "@prb/math": "4.1.0",
-        "@sablier/evm-utils": "github:sablier-labs/evm-utils",
+        "@sablier/evm-utils": "github:sablier-labs/evm-utils#31f94ff",
       },
       "devDependencies": {
         "@sablier/devkit": "github:sablier-labs/devkit",
@@ -172,7 +172,7 @@
 
     "@sablier/devkit": ["@sablier/devkit@github:sablier-labs/devkit#16816ca", {}, "sablier-labs-devkit-16816ca"],
 
-    "@sablier/evm-utils": ["@sablier/evm-utils@github:sablier-labs/evm-utils#cc3a85c", { "dependencies": { "@chainlink/contracts": "1.3.0" } }, "sablier-labs-evm-utils-cc3a85c"],
+    "@sablier/evm-utils": ["@sablier/evm-utils@github:sablier-labs/evm-utils#31f94ff", { "dependencies": { "@chainlink/contracts": "1.3.0" } }, "sablier-labs-evm-utils-31f94ff"],
 
     "@scroll-tech/contracts": ["@scroll-tech/contracts@0.1.0", "", {}, "sha512-aBbDOc3WB/WveZdpJYcrfvMYMz7ZTEiW8M9XMJLba8p9FAR5KGYB/cV+8+EUsq3MKt7C1BfR+WnXoTVdvwIY6w=="],
 
@@ -414,7 +414,7 @@
 
     "got": ["got@12.6.1", "", { "dependencies": { "@sindresorhus/is": "^5.2.0", "@szmarczak/http-timer": "^5.0.1", "cacheable-lookup": "^7.0.0", "cacheable-request": "^10.2.8", "decompress-response": "^6.0.0", "form-data-encoder": "^2.1.2", "get-stream": "^6.0.1", "http2-wrapper": "^2.1.10", "lowercase-keys": "^3.0.0", "p-cancelable": "^3.0.0", "responselike": "^3.0.0" } }, "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ=="],
 
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+    "graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -809,8 +809,6 @@
     "@openzeppelin/upgrades-core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@openzeppelin/upgrades-core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "better-ajv-errors/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -414,7 +414,7 @@
 
     "got": ["got@12.6.1", "", { "dependencies": { "@sindresorhus/is": "^5.2.0", "@szmarczak/http-timer": "^5.0.1", "cacheable-lookup": "^7.0.0", "cacheable-request": "^10.2.8", "decompress-response": "^6.0.0", "form-data-encoder": "^2.1.2", "get-stream": "^6.0.1", "http2-wrapper": "^2.1.10", "lowercase-keys": "^3.0.0", "p-cancelable": "^3.0.0", "responselike": "^3.0.0" } }, "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ=="],
 
-    "graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -809,6 +809,8 @@
     "@openzeppelin/upgrades-core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@openzeppelin/upgrades-core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "better-ajv-errors/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "5.3.0",
     "@prb/math": "4.1.0",
-    "@sablier/evm-utils": "github:sablier-labs/evm-utils"
+    "@sablier/evm-utils": "github:sablier-labs/evm-utils#31f94ff"
   },
   "devDependencies": {
     "@sablier/devkit": "github:sablier-labs/devkit",

--- a/src/interfaces/ISablierLockup.sol
+++ b/src/interfaces/ISablierLockup.sol
@@ -87,6 +87,11 @@ interface ISablierLockup is
                           USER-FACING READ-ONLY FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @notice Calculates the minimum fee in wei required to withdraw from the given stream ID.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream ID for the query.
+    function calculateMinFeeWei(uint256 streamId) external view returns (uint256 minFeeWei);
+
     /// @notice Retrieves the stream's recipient.
     /// @dev Reverts if the NFT has been burned.
     /// @param streamId The stream ID for the query.

--- a/tests/integration/concrete/lockup/calculate-min-fee-wei-for/calculateMinFeeWeiFor.t.sol
+++ b/tests/integration/concrete/lockup/calculate-min-fee-wei-for/calculateMinFeeWeiFor.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierComptroller.sol";
+
+import { Integration_Test } from "../../../Integration.t.sol";
+
+contract CalculateMinFeeWeiFor_Integration_Concrete_Test is Integration_Test {
+    function test_RevertGiven_Null() external {
+        expectRevert_Null({ callData: abi.encodeCall(lockup.calculateMinFeeWei, ids.nullStream) });
+    }
+
+    function test_GivenCustomFeeSet() external givenNotNull {
+        setMsgSender(admin);
+
+        uint256 customFeeUSD = 100e8; // 100 USD.
+
+        // Set the custom fee.
+        comptroller.setCustomFeeUSDFor({
+            protocol: ISablierComptroller.Protocol.Lockup,
+            user: users.sender,
+            customFeeUSD: customFeeUSD
+        });
+
+        uint256 expectedFeeWei = (1e18 * customFeeUSD) / 3000e8; // at $3000 per ETH
+
+        // It should return the custom fee in wei.
+        assertEq(lockup.calculateMinFeeWei(ids.defaultStream), expectedFeeWei, "customFeeWei");
+    }
+
+    function test_GivenCustomFeeNotSet() external view givenNotNull {
+        // It should return the minimum fee in wei.
+        assertEq(lockup.calculateMinFeeWei(ids.defaultStream), LOCKUP_MIN_FEE_WEI, "minFeeWei");
+    }
+}

--- a/tests/integration/concrete/lockup/calculate-min-fee-wei-for/calculateMinFeeWeiFor.t.sol
+++ b/tests/integration/concrete/lockup/calculate-min-fee-wei-for/calculateMinFeeWeiFor.t.sol
@@ -22,7 +22,7 @@ contract CalculateMinFeeWeiFor_Integration_Concrete_Test is Integration_Test {
             customFeeUSD: customFeeUSD
         });
 
-        uint256 expectedFeeWei = (1e18 * customFeeUSD) / 3000e8; // at $3000 per ETH
+        uint256 expectedFeeWei = (1e18 * customFeeUSD) / ETH_PRICE_USD;
 
         // It should return the custom fee in wei.
         assertEq(lockup.calculateMinFeeWei(ids.defaultStream), expectedFeeWei, "customFeeWei");

--- a/tests/integration/concrete/lockup/calculate-min-fee-wei-for/calculateMinFeeWeiFor.tree
+++ b/tests/integration/concrete/lockup/calculate-min-fee-wei-for/calculateMinFeeWeiFor.tree
@@ -1,0 +1,8 @@
+CalculateMinFeeWeiFor_Integration_Concrete_Test
+├── given null
+│  └── it should revert
+└── given not null
+   ├── given custom fee set
+   │  └── it should return the custom fee in wei
+   └── given custom fee not set
+      └── it should return the minimum fee in wei


### PR DESCRIPTION
Refer to https://github.com/sablier-labs/evm-utils/pull/44.

Depends on https://github.com/sablier-labs/lockup/pull/1268.

### Note

The new function `calculateMinFeeWei` is added to Lockup contract because it would be useful for external contracts to query fee for a given stream ID from the Lockup contract itself and then use the returned value in the withdraw function. Without the function, they will have to query it from comptroller using stream's sender and then use that value in withdraw function - a poor UX.